### PR TITLE
Fix: Prevent decoding of special uri characters

### DIFF
--- a/src/handler.lua
+++ b/src/handler.lua
@@ -16,7 +16,7 @@ end
 function plugin:access(conf) -- Executed for every request upon it's reception from a client and before it is being proxied to the upstream service.
   plugin.super.access(self)
 
-  local newstr, n, err = ngx.re.sub(ngx.var.uri, conf.regex, conf.replace)
+  local newstr, n, err = ngx.re.sub(ngx.escape_uri(ngx.var.uri, 0), conf.regex, conf.replace)
   if n > 0 then
       ngx.var.upstream_uri = newstr
       ngx.log(ngx.NOTICE, string.format("%s ---> %s", ngx.var.uri, ngx.var.upstream_uri))


### PR DESCRIPTION
This code by default is doing URI decoding and that's why if special characters are passed in the URI, bad request will be sent to upstream service and probably produce HTTP error code 400.
So what we need is to escape special characters by using [ngx.escape_uri(str, type?)](https://github.com/openresty/lua-nginx-module#ngxescape_uri) function, before this change was applied upstream service was receiving this URI `/b/code/R0E 1A0` instead of this one `/b/code/R0E%201A0`. 

Before:
```plain
2022/03/10 11:42:44 [notice] 1098#0: *1665 [lua] handler.lua:22: /a/code/R0E 1A0 ---> /b/code/R0E 1A0, client: 10.x.x.x, server: kong, request: "GET /a/code/R0E%201A0 HTTP/1.1", host: "kong.example.com"
```

After:
```plain
2022/03/10 11:52:44 [notice] 1098#0: *1665 [lua] handler.lua:22: /a/code/R0E 1A0 ---> /b/code/R0E%201A0, client: 10.x.x.x, server: kong, request: "GET /a/code/R0E%201A0 HTTP/1.1", host: "kong.example.com"
```

Btw very useful plugin, thank you!